### PR TITLE
added ceph-disk activate command to activate the partition and added

### DIFF
--- a/lib/ceph/utils.py
+++ b/lib/ceph/utils.py
@@ -943,7 +943,7 @@ def get_partition_list(dev):
         partitions = get_partitions(dev)
         # For each line of output
         for partition in partitions:
-            parts = partition.split()
+            parts = partition.split(' ')
             partitions_list.append(
                 Partition(number=parts[0],
                           start=parts[1],
@@ -1489,6 +1489,8 @@ def osdize_dev(dev, osd_format, osd_journal, reformat_osd=False,
     try:
         log("osdize cmd: {}".format(cmd))
         subprocess.check_call(cmd)
+        #Command to activate the partitions
+        subprocess.check_call(['ceph-disk', 'activate', dev])
     except subprocess.CalledProcessError:
         if ignore_errors:
             log('Unable to initialize device: {}'.format(dev), WARNING)


### PR DESCRIPTION
**Background**: I wanted to deploy ceph-osd on single-disk node. Where Operating system and ceph-osd block device shares the same disk (by creating partitions).

**Issue** : Failed to deploy ceph-osd on partition with the following error on juju status “**Unable to find block device /dev/sda2**”

**Observation**: On analysing logs, could observe that ceph-disk prepare command was executed for disk partition but the activation of disk partition logs were missing. Further debugging of code, led me to the below function in   “**cs:ceph-osd-249**” charm

def osdize_dev(dev, osd_format, osd_journal, reformat_osd=False,
                ignore_errors=False, encrypt=False, bluestore=False):
…..

Where the command for activation of disk partition were missing and could handle only the activation of entire disk.

**Resolution**: Added “_ceph-disk activate_” command in the above mentioned function after “ceph-disk prepare” in lib/ceph/util.py. On adding this command deployment of ceph-osd on partition was successful.

**Note**: During the addition of “_ceph-disk activate_” command , ran into one more issue where an empty value in the partition array seen , when tried to split using split method was throwing an error due to inaccessibility of the value. Addition of space as a delimiter while splitting partition array resolved the issue.
