### PR TITLE
Provide the real path of device for ceph to prepare

### DIFF
--- a/lib/ceph/utils.py
+++ b/lib/ceph/utils.py
@@ -1487,7 +1487,7 @@ def osdize_dev(dev, osd_format, osd_journal, ignore_errors=False,
                            bluestore,
                            key_manager)
     else:
-        cmd = _ceph_disk(dev,
+        cmd = _ceph_disk(os.path.realpath(dev),
                          osd_format,
                          osd_journal,
                          encrypt,


### PR DESCRIPTION
This is a followup patch for the previous commits that are addressing issues
with bcache based configuration.

Providing dname path for ceph-disk is unsafe, the prepare command
uses gdisk which breaks the dname symlinks.