### PR TITLE
add local modules to sys.path with insert instead of append

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 import sys
-sys.path.append('hooks')
-sys.path.append('lib')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')

--- a/actions/add_disk.py
+++ b/actions/add_disk.py
@@ -18,8 +18,8 @@ import os
 import psutil
 import sys
 
-sys.path.append('lib')
-sys.path.append('hooks')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')
 
 import charmhelpers.contrib.storage.linux.ceph as ch_ceph
 import charmhelpers.core.hookenv as hookenv

--- a/actions/blacklist.py
+++ b/actions/blacklist.py
@@ -17,7 +17,7 @@
 import os
 import sys
 
-sys.path.append('hooks')
+sys.path.insert(0, 'hooks')
 
 import charmhelpers.core.hookenv as hookenv
 import charmhelpers.core.unitdata as unitdata

--- a/actions/list_disks.py
+++ b/actions/list_disks.py
@@ -31,8 +31,8 @@ and are currently not eligible for use because of presence of foreign data.
 import sys
 import os
 
-sys.path.append('hooks/')
-sys.path.append('lib/')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')
 
 import charmhelpers.core.hookenv as hookenv
 

--- a/actions/osd_in_out.py
+++ b/actions/osd_in_out.py
@@ -21,8 +21,8 @@ import sys
 
 from subprocess import check_output, STDOUT
 
-sys.path.append('lib')
-sys.path.append('hooks')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')
 
 from charmhelpers.core.hookenv import (
     function_fail,

--- a/actions/security_checklist.py
+++ b/actions/security_checklist.py
@@ -16,7 +16,7 @@
 
 import sys
 
-sys.path.append('hooks')
+sys.path.insert(0, 'hooks')
 
 import charmhelpers.contrib.openstack.audits as audits
 from charmhelpers.contrib.openstack.audits import (

--- a/actions/service.py
+++ b/actions/service.py
@@ -21,8 +21,8 @@ import shutil
 import subprocess
 
 
-sys.path.append('lib')
-sys.path.append('hooks')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')
 
 from charmhelpers.core.hookenv import (
     function_fail,

--- a/actions/zap_disk.py
+++ b/actions/zap_disk.py
@@ -17,8 +17,8 @@
 import os
 import sys
 
-sys.path.append('lib')
-sys.path.append('hooks')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'hooks')
 
 import charmhelpers.core.hookenv as hookenv
 from charmhelpers.contrib.storage.linux.utils import (

--- a/hooks/ceph_hooks.py
+++ b/hooks/ceph_hooks.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import traceback
 
-sys.path.append('lib')
+sys.path.insert(0, 'lib')
 import charms_ceph.utils as ceph
 from charmhelpers.core import hookenv
 from charmhelpers.core.hookenv import (

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -18,7 +18,7 @@ import socket
 import subprocess
 import sys
 
-sys.path.append('lib')
+sys.path.insert(0, 'lib')
 import charms_ceph.utils as ceph
 
 from charmhelpers.core.hookenv import (

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-sys.path.append('hooks')
-sys.path.append('lib')
-sys.path.append('actions')
-sys.path.append('unit_tests')
+sys.path.insert(0, 'hooks')
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'actions')
+sys.path.insert(0, 'unit_tests')

--- a/unit_tests/test_actions_osd_out_in.py
+++ b/unit_tests/test_actions_osd_out_in.py
@@ -18,7 +18,7 @@ import sys
 
 from test_utils import CharmTestCase
 
-sys.path.append('hooks')
+sys.path.insert(0, 'hooks')
 
 import osd_in_out as actions
 


### PR DESCRIPTION
local module paths should be inserted into beginning of sys.path, so they can be used first by python interpreter.
Otherwise when a global copy exists, local copy will be ignored, and cause unexpected error.

For example, `charmhelpers` error in this bug:
LP: #1919949

Change-Id: Idd61274b7abd0226b625cf334ab0b7f125146aec
Signed-off-by: Joe Guo <joe.guo@canonical.com>